### PR TITLE
Bugfix/2 types node

### DIFF
--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -71,6 +71,7 @@ trait ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExe
   test("recharts")(assertImportsOk("recharts", pedantic                             = true))
   test("firebase")(assertImportsOk("firebase", pedantic                             = true))
   test("prisma")(assertImportsOk("prisma", pedantic                                 = true))
+  test("node")(assertImportsOk("node", pedantic                                     = false))
 
   test("material-ui-slinky")(
     assertImportsOk("material-ui", pedantic = true, flavour = Slinky),

--- a/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
+++ b/importer/src/test/scala/org/scalablytyped/converter/internal/importer/ImporterTest.scala
@@ -71,7 +71,7 @@ trait ImporterTest extends AnyFunSuite with ImporterHarness with ParallelTestExe
   test("recharts")(assertImportsOk("recharts", pedantic                             = true))
   test("firebase")(assertImportsOk("firebase", pedantic                             = true))
   test("prisma")(assertImportsOk("prisma", pedantic                                 = true))
-  test("node")(assertImportsOk("node", pedantic                                     = false))
+  test("node")(assertImportsOk("node", pedantic                                     = true))
 
   test("material-ui-slinky")(
     assertImportsOk("material-ui", pedantic = true, flavour = Slinky),

--- a/sbt-converter/src/sbt-test/react/sourcegen-mixed/build.sbt
+++ b/sbt-converter/src/sbt-test/react/sourcegen-mixed/build.sbt
@@ -25,6 +25,6 @@ lazy val lib =
         "@types/express" -> "4.17.2",
       ),
       stMinimize := Selection.AllExcept("express", "node"),
-      stStdlib := List("es5"),
+      stStdlib := List("es2015"),
       stOutputPackage := "mytypings",
     )

--- a/sbt-converter/src/sbt-test/react/sourcegen/build.sbt
+++ b/sbt-converter/src/sbt-test/react/sourcegen/build.sbt
@@ -8,7 +8,7 @@ lazy val testProject =
         "@types/express" -> "4.17.2",
       ),
       stMinimize := Selection.AllExcept("express", "node"),
-      stStdlib := List("es5"),
+      stStdlib := List("es2015"),
       scalaJSUseMainModuleInitializer := true,
       scalaVersion := "2.13.2",
       organization := "com.olvind",

--- a/tests/node/check-3/n/node/build.sbt
+++ b/tests/node/check-3/n/node/build.sbt
@@ -1,0 +1,11 @@
+organization := "org.scalablytyped"
+name := "node"
+version := "0.0-unknown-1e5d6f"
+scalaVersion := "3.3.1"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2",
+  "org.scalablytyped" %%% "std" % "0.0-unknown-952531")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/node/check-3/n/node/build.sbt
+++ b/tests/node/check-3/n/node/build.sbt
@@ -1,6 +1,6 @@
 organization := "org.scalablytyped"
 name := "node"
-version := "0.0-unknown-1e5d6f"
+version := "0.0-unknown-397bc5"
 scalaVersion := "3.3.1"
 enablePlugins(ScalaJSPlugin)
 libraryDependencies ++= Seq(

--- a/tests/node/check-3/n/node/project/build.properties
+++ b/tests/node/check-3/n/node/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.6

--- a/tests/node/check-3/n/node/project/plugins.sbt
+++ b/tests/node/check-3/n/node/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")

--- a/tests/node/check-3/n/node/readme.md
+++ b/tests/node/check-3/n/node/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for node
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/node/check-3/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/node/check-3/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -9,10 +9,11 @@ object NodeJS {
   // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
   /** NOTE: Conditional type definitions are impossible to translate to Scala.
     * See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html for an intro.
-    * This RHS of the type alias is guess work. You should cast if it's not correct in your case.
+    * You'll have to cast your way around this structure, unfortunately.
     * TS definition: {{{
-    std.ReturnType<std.Array<any>[symbol]> extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify globalThis.Iterator<any, infer TReturn> * / any ? TReturn : any
+    std.ReturnType<std.Array<any>[symbol]> extends std.Iterator<any, infer TReturn, undefined> ? TReturn : any
     }}}
     */
-  type BuiltinIteratorReturn = TReturn
+  @js.native
+  trait BuiltinIteratorReturn extends StObject
 }

--- a/tests/node/check-3/n/node/src/main/scala/typings/node/NodeJS.scala
+++ b/tests/node/check-3/n/node/src/main/scala/typings/node/NodeJS.scala
@@ -1,0 +1,18 @@
+package typings.node
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object NodeJS {
+  
+  // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
+  /** NOTE: Conditional type definitions are impossible to translate to Scala.
+    * See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html for an intro.
+    * This RHS of the type alias is guess work. You should cast if it's not correct in your case.
+    * TS definition: {{{
+    std.ReturnType<std.Array<any>[symbol]> extends / * import warning: transforms.QualifyReferences#resolveTypeRef many Couldn't qualify globalThis.Iterator<any, infer TReturn> * / any ? TReturn : any
+    }}}
+    */
+  type BuiltinIteratorReturn = TReturn
+}

--- a/tests/node/check-3/n/node/src/main/scala/typings/node/nodeRequire.scala
+++ b/tests/node/check-3/n/node/src/main/scala/typings/node/nodeRequire.scala
@@ -1,0 +1,11 @@
+package typings.node
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("node", JSImport.Namespace)
+@js.native
+object nodeRequire extends StObject

--- a/tests/node/check-3/s/std/build.sbt
+++ b/tests/node/check-3/s/std/build.sbt
@@ -1,0 +1,10 @@
+organization := "org.scalablytyped"
+name := "std"
+version := "0.0-unknown-952531"
+scalaVersion := "3.3.1"
+enablePlugins(ScalaJSPlugin)
+libraryDependencies ++= Seq(
+  "com.olvind" %%% "scalablytyped-runtime" % "2.4.2")
+publishArtifact in packageDoc := false
+scalacOptions ++= List("-encoding", "utf-8", "-feature", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-no-indent", "-source:future")
+licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/tests/node/check-3/s/std/project/build.properties
+++ b/tests/node/check-3/s/std/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.6

--- a/tests/node/check-3/s/std/project/plugins.sbt
+++ b/tests/node/check-3/s/std/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" %% "sbt-scalajs" % "1.11.0")

--- a/tests/node/check-3/s/std/readme.md
+++ b/tests/node/check-3/s/std/readme.md
@@ -1,0 +1,15 @@
+
+# Scala.js typings for std
+
+
+
+
+## Note
+This library has been generated from typescript code from first party type definitions.
+
+Provided with :purple_heart: from [ScalablyTyped](https://github.com/oyvindberg/ScalablyTyped)
+
+## Usage
+See [the main readme](../../readme.md) for instructions.
+
+

--- a/tests/node/check-3/s/std/src/main/scala/typings/std/Array.scala
+++ b/tests/node/check-3/s/std/src/main/scala/typings/std/Array.scala
@@ -1,0 +1,7 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+trait Array[T] extends StObject

--- a/tests/node/check-3/s/std/src/main/scala/typings/std/Iterator.scala
+++ b/tests/node/check-3/s/std/src/main/scala/typings/std/Iterator.scala
@@ -1,0 +1,8 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+// from lib.es2015.iterable.d.ts
+trait Iterator[T, TReturn, TNext] extends StObject

--- a/tests/node/check-3/s/std/src/main/scala/typings/std/ReturnType.scala
+++ b/tests/node/check-3/s/std/src/main/scala/typings/std/ReturnType.scala
@@ -1,0 +1,18 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/**
+  * Obtain the return type of a function type
+  */
+/** NOTE: Conditional type definitions are impossible to translate to Scala.
+  * See https://www.typescriptlang.org/docs/handbook/2/conditional-types.html for an intro.
+  * You'll have to cast your way around this structure, unfortunately.
+  * TS definition: {{{
+  T extends (args : ...any): infer R ? R : any
+  }}}
+  */
+@js.native
+trait ReturnType[T /* <: js.Function1[/* repeated */ Any, Any] */] extends StObject

--- a/tests/node/check-3/s/std/src/main/scala/typings/std/SymbolConstructor.scala
+++ b/tests/node/check-3/s/std/src/main/scala/typings/std/SymbolConstructor.scala
@@ -1,0 +1,24 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+// from lib.es2015.iterable.d.ts
+trait SymbolConstructor extends StObject {
+  
+  val iterator: js.Symbol
+}
+object SymbolConstructor {
+  
+  inline def apply(iterator: js.Symbol): SymbolConstructor = {
+    val __obj = js.Dynamic.literal(iterator = iterator.asInstanceOf[js.Any])
+    __obj.asInstanceOf[SymbolConstructor]
+  }
+  
+  @scala.inline
+  implicit open class MutableBuilder[Self <: SymbolConstructor] (val x: Self) extends AnyVal {
+    
+    inline def setIterator(value: js.Symbol): Self = StObject.set(x, "iterator", value.asInstanceOf[js.Any])
+  }
+}

--- a/tests/node/check-3/s/std/src/main/scala/typings/std/global.scala
+++ b/tests/node/check-3/s/std/src/main/scala/typings/std/global.scala
@@ -1,0 +1,13 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+object global {
+  
+  // from lib.es2015.symbol.d.ts 
+  @JSGlobal("Symbol")
+  @js.native
+  val Symbol: SymbolConstructor = js.native
+}

--- a/tests/node/check-3/s/std/src/main/scala/typings/std/stdRequire.scala
+++ b/tests/node/check-3/s/std/src/main/scala/typings/std/stdRequire.scala
@@ -1,0 +1,11 @@
+package typings.std
+
+import org.scalablytyped.runtime.StObject
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSGlobalScope, JSGlobal, JSImport, JSName, JSBracketAccess}
+
+/* This can be used to `require` the library as a side effect.
+  If it is a global library this will make scalajs-bundler include it */
+@JSImport("std", JSImport.Namespace)
+@js.native
+object stdRequire extends StObject

--- a/tests/node/in/node/compatibility/iterators.d.ts
+++ b/tests/node/in/node/compatibility/iterators.d.ts
@@ -1,0 +1,14 @@
+// Backwards-compatible iterator interfaces, augmented with iterator helper methods by lib.esnext.iterator in TypeScript 5.6.
+// The IterableIterator interface does not contain these methods, which creates assignability issues in places where IteratorObjects
+// are expected (eg. DOM-compatible APIs) if lib.esnext.iterator is loaded.
+// Also ensures that iterators returned by the Node API, which inherit from Iterator.prototype, correctly expose the iterator helper methods
+// if lib.esnext.iterator is loaded.
+// TODO: remove once this package no longer supports TS 5.5, and replace NodeJS.BuiltinIteratorReturn with BuiltinIteratorReturn.
+
+
+declare namespace NodeJS {
+    // Polyfill for TS 5.6's instrinsic BuiltinIteratorReturn type, required for DOM-compatible iterators
+    type BuiltinIteratorReturn = ReturnType<any[][typeof Symbol.iterator]> extends
+        globalThis.Iterator<any, infer TReturn> ? TReturn
+        : any;
+}

--- a/tests/node/in/stdlib.d.ts
+++ b/tests/node/in/stdlib.d.ts
@@ -1,0 +1,20 @@
+
+declare interface Array<T> {
+}
+
+/**
+ * Obtain the return type of a function type
+ */
+type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) => infer R ? R : any;
+
+// from lib.es2015.iterable.d.ts
+interface SymbolConstructor {
+    readonly iterator: unique symbol;
+}
+
+// from lib.es2015.symbol.d.ts 
+declare var Symbol: SymbolConstructor;
+
+// from lib.es2015.iterable.d.ts
+interface Iterator<T, TReturn = any, TNext = undefined> {
+}

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/TsTreeScope.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/TsTreeScope.scala
@@ -72,7 +72,7 @@ sealed trait TsTreeScope {
       qname:          TsQIdent,
       skipValidation: Boolean = false,
   ): IArray[(T, TsTreeScope)] = {
-    if ((TsQIdent.Primitive(qname)) || isAbstract(qname))
+    if (TsQIdent.Primitive(qname) || isAbstract(qname))
       return Empty
 
     val res = lookupInternal(picker, qname.parts, LoopDetector.initial)
@@ -108,7 +108,8 @@ sealed trait TsTreeScope {
             while (shouldSkip(skipScopes)) skipScopes = skipScopes.`..`
 
             skipScopes.lookupImpl(picker, rest, newLoopDetector)
-          case other => lookupImpl(picker, other, newLoopDetector)
+          case IArray.headTail(TsIdentSimple("globalThis"), rest) => root.lookupImpl(picker, rest, newLoopDetector)
+          case other                                              => lookupImpl(picker, other, newLoopDetector)
         }
     }
 

--- a/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/QualifyReferences.scala
+++ b/ts/src/main/scala/org/scalablytyped/converter/internal/ts/transforms/QualifyReferences.scala
@@ -52,7 +52,7 @@ class QualifyReferences(skipValidation: Boolean) extends TreeTransformationScope
     x.copy(parent = qualified.headOption, implements = qualified.drop(1))
   }
 
-  def resolveTypeRef(
+  private def resolveTypeRef(
       scope:       TsTreeScope,
       tr:          TsTypeRef,
       maybeFilter: Option[TsNamedDecl => Boolean],
@@ -79,7 +79,7 @@ class QualifyReferences(skipValidation: Boolean) extends TreeTransformationScope
       many.take(1)
     } else IArray(tr)
 
-  def shouldQualify(name: TsQIdent, scope: TsTreeScope): Boolean =
+  private def shouldQualify(name: TsQIdent, scope: TsTreeScope): Boolean =
     if (TsQIdent.Primitive(name)) false
     else if (name.parts.head.isInstanceOf[TsIdentLibrary]) false
     else if (scope.isAbstract(name)) false


### PR DESCRIPTION
fix #2 

### Overview

This pull request addresses bug fixes related to `@types/node`.

### Changes

- Added a new import test (`ImporterTest.scala`).
- Added support for `globalThis` in the `TsTreeScope`.
- Changed `stStdlib` from `es5` to `es2015` in scripted test.
    - scripted test is failed due to the `Iterator` referenced by `@types/node`