### PR TITLE
use `$GITHUB_OUTPUT` instead of `::set-output`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Get tests folder sha
         id: get-tests-folder-sha
         run: |
-          echo "::set-output name=sha::$(git ls-tree HEAD tests --object-only)"
+          echo "sha=$(git ls-tree HEAD tests --object-only)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
to suppress deprecated messages

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```